### PR TITLE
Introduce testmon to speed up test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 # Project specific
 lrsystem_output/
+.testmondata
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:5a775a6ecbb9213c373e54fede6de87fb0a4f1160ff2f06dacc649e1fa52e87f"
+content_hash = "sha256:7fa1a10da78e9318c6fe51108a192509374c4378e9af52578460a2b91d86117b"
 
 [[metadata.targets]]
 requires_python = ">=3.13,<3.14"
@@ -1060,6 +1060,21 @@ dependencies = [
 files = [
     {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
     {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+]
+
+[[package]]
+name = "pytest-testmon"
+version = "2.1.4"
+requires_python = ">=3.8"
+summary = "selects tests affected by changed files and methods"
+groups = ["dev"]
+dependencies = [
+    "coverage<8,>=6",
+    "pytest<9,>=5",
+]
+files = [
+    {file = "pytest_testmon-2.1.4-py3-none-any.whl", hash = "sha256:3d1178b455a727c94dde85228a34b7ef857751ba142c15874df82d8876e31194"},
+    {file = "pytest_testmon-2.1.4.tar.gz", hash = "sha256:cc3dd31f9bf30f6ec11c5153da3c606df7545f3cd90bfb90ce6bd4c48e717aaf"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
     "ruff>=0.14.5",
     "ty>=0.0.1a26",
     "coverage>=7.11.3",
+    "pytest-testmon>=2.1.4",
 ]
 
 [tool.pdm]
@@ -29,6 +30,7 @@ version = {source = "scm"}
 
 [tool.pdm.scripts]
 all = {composite = ["check", "test"]}
+all_with_quicktest = {composite = ["check", "quicktest"]}
 check = {composite = ["lint", "format-check", "check-static"]}
 all-fix = {composite = ["check-quality", "test"]}
 
@@ -43,6 +45,7 @@ format-fix = "ruff format lrmodule/"
 
 # If no args are given to 'test', this will run as if '{args}' is an empty string.
 test = "coverage run --branch --source lir --module pytest --strict-markers tests/ {args}"
+quicktest = {composite = ["test --testmon"]}
 
 
 # Following Scratch conventions on linting, type hinting, etc.


### PR DESCRIPTION
Since the current test suite takes up to 30 seconds to finish (mainly due to the MCMC calculations), the `pdm run quicktest` command was introduced to run the tests with `pytest-testmon` to only run the tests that are covering files that have been updated.

It remains good practice to run the complete test suite using `pdm run test` to verify *all* tests remain green.

Furthermore, `pytest` was downgraded, as `pytest-testmon` does not currently support `pytest>9.0` yet.