### PR TITLE
Introduce pytest-randomly to run all unit tests in random order

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:53f3fe60f24f96433b9049d47edda3ffa317de8e9ad1dcc01f5d6661e9eb7e21"
+content_hash = "sha256:55c752c5bb08a86892f89c1644ec62e8d6ff4eef0a880475512e00c74cf65ec5"
 
 [[metadata.targets]]
 requires_python = ">=3.13,<3.14"
@@ -386,7 +386,7 @@ name = "iniconfig"
 version = "2.3.0"
 requires_python = ">=3.10"
 summary = "brain-dead simple config-ini parsing"
-groups = ["dev"]
+groups = ["default", "dev"]
 files = [
     {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
     {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
@@ -880,7 +880,7 @@ name = "pluggy"
 version = "1.6.0"
 requires_python = ">=3.9"
 summary = "plugin and hook calling mechanisms for python"
-groups = ["dev"]
+groups = ["default", "dev"]
 files = [
     {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
     {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
@@ -1033,7 +1033,7 @@ name = "pytest"
 version = "8.4.2"
 requires_python = ">=3.9"
 summary = "pytest: simple powerful testing with Python"
-groups = ["dev"]
+groups = ["default", "dev"]
 dependencies = [
     "colorama>=0.4; sys_platform == \"win32\"",
     "exceptiongroup>=1; python_version < \"3.11\"",
@@ -1046,6 +1046,21 @@ dependencies = [
 files = [
     {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
     {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+]
+
+[[package]]
+name = "pytest-randomly"
+version = "4.0.1"
+requires_python = ">=3.9"
+summary = "Pytest plugin to randomly order tests and control random.seed."
+groups = ["default"]
+dependencies = [
+    "importlib-metadata>=3.6; python_version < \"3.10\"",
+    "pytest",
+]
+files = [
+    {file = "pytest_randomly-4.0.1-py3-none-any.whl", hash = "sha256:e0dfad2fd4f35e07beff1e47c17fbafcf98f9bf4531fd369d9260e2f858bfcb7"},
+    {file = "pytest_randomly-4.0.1.tar.gz", hash = "sha256:174e57bb12ac2c26f3578188490bd333f0e80620c3f47340158a86eca0593cd8"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 requires-python = ">=3.13, <3.14"  # `pytensor` (required by `pymc` doesn't support python 3.14 yet)
 readme = "README.md"
 license = {text = "Apache Software License 2.0"}
-dependencies = ["lir==1.2.0", "pandas>=2.3.3", "arviz>=0.22.0", "pymc>=5.26.1"]
+dependencies = ["lir==1.2.0", "pandas>=2.3.3", "arviz>=0.22.0", "pymc>=5.26.1", "pytest-randomly>=4.0.1"]
 
 [project.urls]
 homepage = "https://github.com/NetherlandsForensicInstitute/lr_module_scratch/"


### PR DESCRIPTION
Running unit tests in random order ensures the tests are not coupled and can be run independently.