### PR TITLE
Create the outputs needed for the validation pipeline 

### DIFF
--- a/lrmodule/copy_csv.py
+++ b/lrmodule/copy_csv.py
@@ -2,7 +2,8 @@ import shutil
 from pathlib import Path
 
 import pandas as pd
-from lir.aggregation import Aggregation, ContextAwareDict, config_parser, pop_field
+from lir.aggregation import Aggregation, ContextAwareDict, config_parser, partial, pop_field
+from lir.util import check_type
 
 
 class CopyCSV(Aggregation):
@@ -11,20 +12,20 @@ class CopyCSV(Aggregation):
     Attributes
     ----------
         source_file (str): The path to the source CSV file that should be copied.
-        target_path (str): The directory where the new CSV file will be saved. Given by the config_parser, meaning
+        target_dir (str): The directory where the new CSV file will be saved. Given by the config_parser, meaning
                             it is not set by the user in the configuration.
         columns (list[str]): A list of column names to copy from the source CSV. If empty, all columns will be copied.
         new_file_name (str): The name of the new CSV file. If empty, the original file name will be used.
     """
 
-    def __init__(self, source_file: str, target_path: str, columns: list[str], new_file_name: str):
+    def __init__(self, source_file: str, target_dir: str, columns: list[str], new_file_name: str | None):
         self.source_file = Path(source_file)
-        self.target_path = Path(target_path)
+        self.target_dir = Path(target_dir)
         self.columns = columns
-        if new_file_name == "":
-            self.new_file_name = self.target_path / self.source_file.name
+        if new_file_name is None:
+            self.new_file_name = self.target_dir / self.source_file.name
         else:
-            self.new_file_name = self.target_path / new_file_name
+            self.new_file_name = self.target_dir / new_file_name
 
     def report(self, data) -> None:
         """Do nothing. Required by parent class."""
@@ -47,6 +48,6 @@ class CopyCSV(Aggregation):
 def copy_csv(config: ContextAwareDict, output_dir: str) -> CopyCSV:
     """Parse the configuration for the CopyCSV aggregation and return an instance of it."""
     source_file = pop_field(config, "file")
-    columns = pop_field(config, "columns", default=[])
-    new_file_name = pop_field(config, "new_file_name", default="")
+    columns = pop_field(config, "columns", default=[], validate=partial(check_type, list))
+    new_file_name = pop_field(config, "new_file_name", required=False)
     return CopyCSV(source_file, output_dir, columns=columns, new_file_name=new_file_name)

--- a/validation.yaml
+++ b/validation.yaml
@@ -188,13 +188,7 @@ experiments:
       - llr_interval
       - method: lrmodule.copy_csv.copy_csv
         file: ${data_root}/breech_face_impression.csv
-      - method: lrmodule.copy_csv.copy_csv
-        file: ${data_root}/breech_face_impression.csv
-        columns:
-          - hypothesis
-          - cmc
-          - n 
-        new_file_name: reference_scores.csv
+        new_file_name: source_data.csv
       - save_model
 
 


### PR DESCRIPTION
Dit is een eerste opzetje, en ik denk dat het op deze manier het makkelijkst is.

Er is een methode `copy_csv`, die een gegeven csv kopieert naar de output folder die bij dat model hoort. 

```
      - method: lrmodule.copy_csv.copy_csv
        file: ${data_root}/breech_face_impression.csv
      - method: lrmodule.copy_csv.copy_csv
        file: ${data_root}/breech_face_impression.csv
        columns:
          - hypothesis
          - cmc
          - n 
        new_file_name: reference_scores.csv
      - save_model
```

Dit geeft
```
> ls
breech_face_impression.csv  
data.yaml                   
ECE.png                     
LLR_Interval.png            
lrsystem.yaml               
metrics.csv                 
PAV.png                     
reference_scores.csv
```

### Voordelen
- Makkelijk te implementeren
- Het specificeren van een naam van het output bestand zorgt dat we altijd dezelfde naam kunnen gebruiken (bijv. `reference_scores.csv`).


### Nadelen
- Werkt niet met subset aggregation.
- Kans op foutjes omdat de naam van het csv-bestand meerder keren moet worden ingevoerd.

